### PR TITLE
removes rendering of books.mustache and creates target id.

### DIFF
--- a/templates/page.mustache
+++ b/templates/page.mustache
@@ -19,9 +19,10 @@
 </body>
 
 <div class="content">
-    <div class="row">
-    {{> books }};
-
+    <div class="row" id="target">
+        <!--loads book data here-->
+        <!--when rendered sucessfully 'Loading...' will disappear-->
+        Loading...
     </div>
 </div>
 </html>


### PR DESCRIPTION
Task 6 and 7. 

Removes original rendering method for books.mustache 
`{{>books}}`
Which is replaced by a callable target id, linking to the div, which contains a static place holder "Loading..." until book data is retireved and displayed